### PR TITLE
Use BigDecimal pow method for exponentiation

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -308,8 +308,8 @@ importers:
         specifier: 0.32.0-watcher-ts-0.1.2
         version: 0.32.0-watcher-ts-0.1.2
       '@graphprotocol/graph-ts':
-        specifier: npm:@cerc-io/graph-ts@0.27.0-watcher-ts-0.1.2
-        version: /@cerc-io/graph-ts@0.27.0-watcher-ts-0.1.2
+        specifier: npm:@cerc-io/graph-ts@0.27.0-watcher-ts-0.1.3
+        version: /@cerc-io/graph-ts@0.27.0-watcher-ts-0.1.3
       abi:
         specifier: workspace:*
         version: link:../../packages/abi
@@ -428,8 +428,8 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@cerc-io/graph-ts@0.27.0-watcher-ts-0.1.2:
-    resolution: {integrity: sha512-tYEWXrbMXNhONqwe329KsS2UcCcYJQ22RhSMJUg+8zsA1RtkLVJR6imVFihsacbBLR8QDMCoVK/FACVguV+Iqw==, tarball: https://git.vdb.to/api/packages/cerc-io/npm/%40cerc-io%2Fgraph-ts/-/0.27.0-watcher-ts-0.1.2/graph-ts-0.27.0-watcher-ts-0.1.2.tgz}
+  /@cerc-io/graph-ts@0.27.0-watcher-ts-0.1.3:
+    resolution: {integrity: sha512-Ipyrx0Ltn/uTaPEgRYUk9MDlfQctoLegBHHmtbijsBJzj6EKNgnUg9plc3TTQS0tubwsjpBnRNi3Ohixsuj+Bw==, tarball: https://git.vdb.to/api/packages/cerc-io/npm/%40cerc-io%2Fgraph-ts/-/0.27.0-watcher-ts-0.1.3/graph-ts-0.27.0-watcher-ts-0.1.3.tgz}
     dependencies:
       assemblyscript: 0.19.10
     dev: true

--- a/subgraphs/v3/package.json
+++ b/subgraphs/v3/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "abi": "workspace:*",
     "@cerc-io/graph-cli": "0.32.0-watcher-ts-0.1.2",
-    "@graphprotocol/graph-ts": "npm:@cerc-io/graph-ts@0.27.0-watcher-ts-0.1.2",
+    "@graphprotocol/graph-ts": "npm:@cerc-io/graph-ts@0.27.0-watcher-ts-0.1.3",
     "assemblyscript": "^0.19.20",
     "matchstick-as": "0.5.0",
     "wabt": "1.0.24"

--- a/subgraphs/v3/src/utils/index.ts
+++ b/subgraphs/v3/src/utils/index.ts
@@ -22,21 +22,7 @@ export function safeDiv(amount0: BigDecimal, amount1: BigDecimal): BigDecimal {
 }
 
 export function bigDecimalExponated(value: BigDecimal, power: BigInt): BigDecimal {
-  if (power.equals(ZERO_BI)) {
-    return ONE_BD
-  }
-  let negativePower = power.lt(ZERO_BI)
-  let result = ZERO_BD.plus(value)
-  let powerAbs = power.abs()
-  for (let i = ONE_BI; i.lt(powerAbs); i = i.plus(ONE_BI)) {
-    result = result.times(value)
-  }
-
-  if (negativePower) {
-    result = safeDiv(ONE_BD, result)
-  }
-
-  return result
+  return value.pow(power.toBigDecimal());
 }
 
 export function tokenAmountToDecimal(tokenAmount: BigInt, exchangeDecimals: BigInt): BigDecimal {


### PR DESCRIPTION
Part of [Run with sushiswap v3 subgraph](https://www.notion.so/Run-with-sushiswap-v3-subgraph-23ab7c56d790487fa73adcc0b3e513fc?pvs=23)

- Upgrade graph-ts package version
- Use new BigDecimal exponentiation method `pow` to avoid error in Mint event processing