### PR TITLE
Upgrade graph-cli in v3 subgraph

### DIFF
--- a/config/filecoin.js
+++ b/config/filecoin.js
@@ -6,7 +6,7 @@ const AXLETH_ADDRESS = '0xb829b68f57cc546da7e5806a929e53be32a4625d'
 const STFIL_ADDRESS = '0x3c3501e6c353dbaeddfa90376975ce7ace4ac7a8'
 const RSPD_ADDRESS = '0x97aae66a1d2a41eac573397b7a5656a9cf3e5616'
 module.exports = {
-  network: 'mainnet',
+  network: 'filecoin',
   blocks: {
     address: '0x719e14fcb364bb05649bd525eb6c4a2d0d4ea2b7',
     startBlock: 2867000,

--- a/config/filecoin.js
+++ b/config/filecoin.js
@@ -6,7 +6,7 @@ const AXLETH_ADDRESS = '0xb829b68f57cc546da7e5806a929e53be32a4625d'
 const STFIL_ADDRESS = '0x3c3501e6c353dbaeddfa90376975ce7ace4ac7a8'
 const RSPD_ADDRESS = '0x97aae66a1d2a41eac573397b7a5656a9cf3e5616'
 module.exports = {
-  network: 'filecoin',
+  network: 'mainnet',
   blocks: {
     address: '0x719e14fcb364bb05649bd525eb6c4a2d0d4ea2b7',
     startBlock: 2867000,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,27 +32,6 @@ importers:
         specifier: ^0.27.0
         version: 0.27.0
 
-  subgraphs/auction-maker:
-    devDependencies:
-      '@graphprotocol/graph-cli':
-        specifier: ^0.60.0
-        version: 0.60.0(@types/node@20.3.2)(node-fetch@2.6.11)(typescript@5.2.2)
-      '@graphprotocol/graph-ts':
-        specifier: ^0.27.0
-        version: 0.27.0
-      abi:
-        specifier: workspace:*
-        version: link:../../packages/abi
-      assemblyscript:
-        specifier: ^0.19.20
-        version: 0.19.23
-      matchstick-as:
-        specifier: 0.5.0
-        version: 0.5.0
-      wabt:
-        specifier: 1.0.24
-        version: 1.0.24
-
   subgraphs/bentobox:
     devDependencies:
       '@graphprotocol/graph-cli':
@@ -89,21 +68,6 @@ importers:
         specifier: 1.0.24
         version: 1.0.24
 
-  subgraphs/candles:
-    devDependencies:
-      '@graphprotocol/graph-cli':
-        specifier: 0.49.0
-        version: 0.49.0(@types/node@20.3.2)(node-fetch@2.6.11)(typescript@5.2.2)
-      '@graphprotocol/graph-ts':
-        specifier: 0.27.0
-        version: 0.27.0
-      '@sushiswap/core':
-        specifier: ^1.4.2
-        version: 1.4.2
-      matchstick-as:
-        specifier: 0.5.0
-        version: 0.5.0
-
   subgraphs/furo:
     devDependencies:
       '@graphprotocol/graph-cli':
@@ -124,24 +88,6 @@ importers:
       wabt:
         specifier: 1.0.24
         version: 1.0.24
-
-  subgraphs/kashi:
-    devDependencies:
-      '@graphprotocol/graph-cli':
-        specifier: ^0.60.0
-        version: 0.60.0(@types/node@20.3.2)(node-fetch@2.6.11)(typescript@5.2.2)
-      '@graphprotocol/graph-ts':
-        specifier: ^0.27.0
-        version: 0.27.0
-      abi:
-        specifier: workspace:*
-        version: link:../../packages/abi
-      matchstick-as:
-        specifier: 0.5.0
-        version: 0.5.0
-      math:
-        specifier: workspace:*
-        version: link:../../packages/math
 
   subgraphs/minichef:
     devDependencies:
@@ -164,30 +110,6 @@ importers:
         specifier: 1.0.24
         version: 1.0.24
 
-  subgraphs/miso:
-    devDependencies:
-      '@graphprotocol/graph-cli':
-        specifier: ^0.60.0
-        version: 0.60.0(@types/node@20.3.2)(node-fetch@2.6.11)(typescript@5.2.2)
-      '@graphprotocol/graph-ts':
-        specifier: ^0.27.0
-        version: 0.27.0
-      '@sushiswap/miso':
-        specifier: 1.0.0-canary.48
-        version: 1.0.0-canary.48
-      abi:
-        specifier: workspace:*
-        version: link:../../packages/abi
-      assemblyscript:
-        specifier: ^0.19.20
-        version: 0.19.23
-      matchstick-as:
-        specifier: 0.5.0
-        version: 0.5.0
-      wabt:
-        specifier: 1.0.24
-        version: 1.0.24
-
   subgraphs/router:
     devDependencies:
       '@graphprotocol/graph-cli':
@@ -196,30 +118,6 @@ importers:
       '@graphprotocol/graph-ts':
         specifier: ^0.27.0
         version: 0.27.0
-      abi:
-        specifier: workspace:*
-        version: link:../../packages/abi
-      assemblyscript:
-        specifier: ^0.19.20
-        version: 0.19.23
-      matchstick-as:
-        specifier: 0.5.0
-        version: 0.5.0
-      wabt:
-        specifier: 1.0.24
-        version: 1.0.24
-
-  subgraphs/staking:
-    devDependencies:
-      '@graphprotocol/graph-cli':
-        specifier: ^0.60.0
-        version: 0.60.0(@types/node@20.3.2)(node-fetch@2.6.11)(typescript@5.2.2)
-      '@graphprotocol/graph-ts':
-        specifier: ^0.27.0
-        version: 0.27.0
-      '@sushiswap/core':
-        specifier: 1.4.2
-        version: 1.4.2
       abi:
         specifier: workspace:*
         version: link:../../packages/abi
@@ -266,42 +164,6 @@ importers:
         specifier: 0.5.0
         version: 0.5.0
 
-  subgraphs/sushiswap-minimal:
-    devDependencies:
-      '@graphprotocol/graph-cli':
-        specifier: ^0.60.0
-        version: 0.60.0(@types/node@20.3.2)(node-fetch@2.6.11)(typescript@5.2.2)
-      '@graphprotocol/graph-ts':
-        specifier: ^0.27.0
-        version: 0.27.0
-      abi:
-        specifier: workspace:*
-        version: link:../../packages/abi
-      matchstick-as:
-        specifier: 0.5.0
-        version: 0.5.0
-
-  subgraphs/trident:
-    devDependencies:
-      '@graphprotocol/graph-cli':
-        specifier: ^0.60.0
-        version: 0.60.0(@types/node@20.3.2)(node-fetch@2.6.11)(typescript@5.2.2)
-      '@graphprotocol/graph-ts':
-        specifier: ^0.27.0
-        version: 0.27.0
-      abi:
-        specifier: workspace:*
-        version: link:../../packages/abi
-      assemblyscript:
-        specifier: ^0.19.20
-        version: 0.19.23
-      matchstick-as:
-        specifier: 0.5.0
-        version: 0.5.0
-      wabt:
-        specifier: 1.0.24
-        version: 1.0.24
-
   subgraphs/v2:
     devDependencies:
       '@graphprotocol/graph-cli':
@@ -326,8 +188,8 @@ importers:
   subgraphs/v3:
     devDependencies:
       '@cerc-io/graph-cli':
-        specifier: 0.32.0-watcher-ts-0.1.2
-        version: 0.32.0-watcher-ts-0.1.2
+        specifier: 0.32.0-watcher-ts-0.1.3
+        version: 0.32.0-watcher-ts-0.1.3
       '@graphprotocol/graph-ts':
         specifier: npm:@cerc-io/graph-ts@0.27.0-watcher-ts-0.1.3
         version: /@cerc-io/graph-ts@0.27.0-watcher-ts-0.1.3
@@ -365,24 +227,6 @@ importers:
         specifier: 1.0.24
         version: 1.0.24
 
-  subgraphs/xswap:
-    devDependencies:
-      '@graphprotocol/graph-cli':
-        specifier: ^0.60.0
-        version: 0.60.0(@types/node@20.3.2)(node-fetch@2.6.11)(typescript@5.2.2)
-      '@graphprotocol/graph-ts':
-        specifier: ^0.27.0
-        version: 0.27.0
-      abi:
-        specifier: workspace:*
-        version: link:../../packages/abi
-      matchstick-as:
-        specifier: 0.5.0
-        version: 0.5.0
-      wabt:
-        specifier: 1.0.24
-        version: 1.0.24
-
 packages:
 
   /@babel/code-frame@7.22.5:
@@ -413,8 +257,8 @@ packages:
       regenerator-runtime: 0.14.0
     dev: true
 
-  /@cerc-io/graph-cli@0.32.0-watcher-ts-0.1.2:
-    resolution: {integrity: sha512-UCvgFBThvP+aaox3Icp17T/vBsSopQdZfdsLYIN/LIsyoRg4NcWdMdYb67pV5OpalLki5RSEhuJLpNJoNEoK4g==, tarball: https://git.vdb.to/api/packages/cerc-io/npm/%40cerc-io%2Fgraph-cli/-/0.32.0-watcher-ts-0.1.2/graph-cli-0.32.0-watcher-ts-0.1.2.tgz}
+  /@cerc-io/graph-cli@0.32.0-watcher-ts-0.1.3:
+    resolution: {integrity: sha512-21W1qGIn8DWKovmQRSs4zPYQJ4gOiAZ4tY4UnCJrOExdZuYgt0ts/gV3RBI+K8L876iDpzgMsW9Get0IhPSxfg==, tarball: https://git.vdb.to/api/packages/cerc-io/npm/%40cerc-io%2Fgraph-cli/-/0.32.0-watcher-ts-0.1.3/graph-cli-0.32.0-watcher-ts-0.1.3.tgz}
     hasBin: true
     dependencies:
       assemblyscript: 0.19.10
@@ -631,49 +475,6 @@ packages:
       js-yaml: 4.1.0
     dev: true
 
-  /@graphprotocol/graph-cli@0.49.0(@types/node@20.3.2)(node-fetch@2.6.11)(typescript@5.2.2):
-    resolution: {integrity: sha512-UZsMTcTZN/EFT/1t8Z253ZtEZXqYQIWKbSox+Q6Fu4bzkK7LlKtoKKrOhxqMfSe2jewFKkCQkVWVC4tXoN+sVQ==}
-    engines: {node: '>=14'}
-    hasBin: true
-    dependencies:
-      '@float-capital/float-subgraph-uncrashable': 0.0.0-internal-testing.5
-      '@oclif/core': 2.8.4(@types/node@20.3.2)(typescript@5.2.2)
-      '@whatwg-node/fetch': 0.8.8
-      assemblyscript: 0.19.23
-      binary-install-raw: 0.0.13(debug@4.3.4)
-      chalk: 3.0.0
-      chokidar: 3.5.3
-      debug: 4.3.4(supports-color@8.1.1)
-      docker-compose: 0.23.19
-      dockerode: 2.5.8
-      fs-extra: 9.1.0
-      glob: 9.3.5
-      gluegun: github.com/edgeandnode/gluegun/b34b9003d7bf556836da41b57ef36eb21570620a(debug@4.3.4)
-      graphql: 15.5.0
-      immutable: 4.2.1
-      ipfs-http-client: 55.0.0(node-fetch@2.6.11)
-      jayson: 4.0.0
-      js-yaml: 3.14.1
-      prettier: 1.19.1
-      request: 2.88.2
-      semver: 7.4.0
-      sync-request: 6.1.0
-      tmp-promise: 3.0.3
-      web3-eth-abi: 1.7.0
-      which: 2.0.2
-      yaml: 1.10.2
-    transitivePeerDependencies:
-      - '@swc/core'
-      - '@swc/wasm'
-      - '@types/node'
-      - bufferutil
-      - encoding
-      - node-fetch
-      - supports-color
-      - typescript
-      - utf-8-validate
-    dev: true
-
   /@graphprotocol/graph-cli@0.60.0(@types/node@20.3.2)(node-fetch@2.6.11)(typescript@5.2.2):
     resolution: {integrity: sha512-8tGaQJ0EzAPtkDXCAijFGoVdJXM+pKFlGxjiU31TdG5bS4cIUoSB6yWojVsFFod0yETAwf+giel/0/8sudYsDw==}
     engines: {node: '>=14'}
@@ -805,46 +606,6 @@ packages:
       object-treeify: 1.1.33
       password-prompt: 1.1.2
       slice-ansi: 4.0.0
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-      supports-color: 8.1.1
-      supports-hyperlinks: 2.3.0
-      ts-node: 10.9.1(@types/node@20.3.2)(typescript@5.2.2)
-      tslib: 2.6.0
-      widest-line: 3.1.0
-      wordwrap: 1.0.0
-      wrap-ansi: 7.0.0
-    transitivePeerDependencies:
-      - '@swc/core'
-      - '@swc/wasm'
-      - '@types/node'
-      - typescript
-    dev: true
-
-  /@oclif/core@2.8.4(@types/node@20.3.2)(typescript@5.2.2):
-    resolution: {integrity: sha512-VlFDhoAJ1RDwcpDF46wAlciWTIryapMUViACttY9GwX6Ci6Lud1awe/pC3k4jad5472XshnPQV4bHAl4a/yxpA==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@types/cli-progress': 3.11.0
-      ansi-escapes: 4.3.2
-      ansi-styles: 4.3.0
-      cardinal: 2.1.1
-      chalk: 4.1.2
-      clean-stack: 3.0.1
-      cli-progress: 3.12.0
-      debug: 4.3.4(supports-color@8.1.1)
-      ejs: 3.1.9
-      fs-extra: 9.1.0
-      get-package-type: 0.1.0
-      globby: 11.1.0
-      hyperlinker: 1.0.0
-      indent-string: 4.0.0
-      is-wsl: 2.2.0
-      js-yaml: 3.14.1
-      natural-orderby: 2.0.3
-      object-treeify: 1.1.33
-      password-prompt: 1.1.2
-      semver: 7.4.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
       supports-color: 8.1.1
@@ -1001,14 +762,6 @@ packages:
 
   /@rescript/std@9.0.0:
     resolution: {integrity: sha512-zGzFsgtZ44mgL4Xef2gOy1hrRVdrs9mcxCOOKZrIPsmbZW14yTkaF591GXxpQvjXiHtgZ/iA9qLyWH6oSReIxQ==}
-    dev: true
-
-  /@sushiswap/core@1.4.2:
-    resolution: {integrity: sha512-Khd2i6Bob9uk7dCgVkhUioEoxRP28m6aj25MegAHvnJyxZPVzZDhxSkeL6wdv5MeAp2DwHkYqUq03KDfVTTP4Q==}
-    dev: true
-
-  /@sushiswap/miso@1.0.0-canary.48:
-    resolution: {integrity: sha512-D7qlWtvH2VjXbptb3hVQgrRYTKZCNFQUrsjjhIeUZIiyzJnrLMiUybwKVQdWPHICXLm6f1WXiy988VpqpE0TYQ==}
     dev: true
 
   /@sushiswap/prettier-config@0.1.0(prettier@2.6.2):
@@ -1288,15 +1041,6 @@ packages:
     resolution: {integrity: sha512-gKC8qb/bDJsPsnEXLZnXJ7gVx7dh87CEVNeIwv1dvaffnXoh5GHwac5pWR1P2broLiVj/fqFMQvLDDt/RhjiqA==}
     dependencies:
       axios: 0.21.4(debug@4.3.1)
-      ramda: 0.25.0
-    transitivePeerDependencies:
-      - debug
-    dev: true
-
-  /apisauce@1.1.5(debug@4.3.4):
-    resolution: {integrity: sha512-gKC8qb/bDJsPsnEXLZnXJ7gVx7dh87CEVNeIwv1dvaffnXoh5GHwac5pWR1P2broLiVj/fqFMQvLDDt/RhjiqA==}
-    dependencies:
-      axios: 0.21.4(debug@4.3.4)
       ramda: 0.25.0
     transitivePeerDependencies:
       - debug
@@ -5438,48 +5182,6 @@ packages:
     hasBin: true
     dependencies:
       apisauce: 1.1.5(debug@4.3.1)
-      app-module-path: 2.2.0
-      cli-table3: 0.5.1
-      colors: 1.3.3
-      cosmiconfig: 6.0.0
-      cross-spawn: 7.0.3
-      ejs: 2.7.4
-      enquirer: 2.3.4
-      execa: 3.4.0
-      fs-jetpack: 2.4.0
-      lodash.camelcase: 4.3.0
-      lodash.kebabcase: 4.1.1
-      lodash.lowercase: 4.3.0
-      lodash.lowerfirst: 4.3.1
-      lodash.pad: 4.5.1
-      lodash.padend: 4.6.1
-      lodash.padstart: 4.6.1
-      lodash.repeat: 4.1.0
-      lodash.snakecase: 4.1.1
-      lodash.startcase: 4.4.0
-      lodash.trim: 4.5.1
-      lodash.trimend: 4.5.1
-      lodash.trimstart: 4.5.1
-      lodash.uppercase: 4.3.0
-      lodash.upperfirst: 4.3.1
-      ora: 4.1.1
-      pluralize: 8.0.0
-      ramdasauce: 2.1.3
-      semver: 7.4.0
-      which: 2.0.2
-      yargs-parser: 16.1.0
-    transitivePeerDependencies:
-      - debug
-    dev: true
-
-  github.com/edgeandnode/gluegun/b34b9003d7bf556836da41b57ef36eb21570620a(debug@4.3.4):
-    resolution: {tarball: https://codeload.github.com/edgeandnode/gluegun/tar.gz/b34b9003d7bf556836da41b57ef36eb21570620a}
-    id: github.com/edgeandnode/gluegun/b34b9003d7bf556836da41b57ef36eb21570620a
-    name: gluegun
-    version: 4.3.1
-    hasBin: true
-    dependencies:
-      apisauce: 1.1.5(debug@4.3.4)
       app-module-path: 2.2.0
       cli-table3: 0.5.1
       colors: 1.3.3

--- a/subgraphs/v3/package.json
+++ b/subgraphs/v3/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "abi": "workspace:*",
-    "@cerc-io/graph-cli": "0.32.0-watcher-ts-0.1.2",
+    "@cerc-io/graph-cli": "0.32.0-watcher-ts-0.1.3",
     "@graphprotocol/graph-ts": "npm:@cerc-io/graph-ts@0.27.0-watcher-ts-0.1.3",
     "assemblyscript": "^0.19.20",
     "matchstick-as": "0.5.0",


### PR DESCRIPTION
Part of [Generate watchers for sushiswap subgraphs deployed in graph-node](https://www.notion.so/Generate-watchers-for-sushiswap-subgraphs-deployed-in-graph-node-b3f2e475373d4ab1887d9f8720bd5ae6)

- Upgrade graph-cli to version `0.32.0-watcher-ts-0.1.3`