### PR TITLE
Use cerc-io graph-cli & graph-ts in route-processor subgraph

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,12 +112,12 @@ importers:
 
   subgraphs/route-processor:
     devDependencies:
-      '@graphprotocol/graph-cli':
-        specifier: ^0.70.0
-        version: 0.70.0(@types/node@20.3.2)(node-fetch@2.6.11)(typescript@5.2.2)
+      '@cerc-io/graph-cli':
+        specifier: 0.32.0-watcher-ts-0.1.3
+        version: 0.32.0-watcher-ts-0.1.3
       '@graphprotocol/graph-ts':
-        specifier: ^0.27.0
-        version: 0.27.0
+        specifier: npm:@cerc-io/graph-ts@0.27.0-watcher-ts-0.1.3
+        version: /@cerc-io/graph-ts@0.27.0-watcher-ts-0.1.3
       abi:
         specifier: workspace:*
         version: link:../../packages/abi

--- a/subgraphs/route-processor/.npmrc
+++ b/subgraphs/route-processor/.npmrc
@@ -1,0 +1,1 @@
+@cerc-io:registry=https://git.vdb.to/api/packages/cerc-io/npm/

--- a/subgraphs/route-processor/package.json
+++ b/subgraphs/route-processor/package.json
@@ -31,8 +31,8 @@
     "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 sushiswap/route-processor-ethereum"
   },
   "devDependencies": {
-    "@graphprotocol/graph-cli": "^0.70.0",
-    "@graphprotocol/graph-ts": "^0.27.0",
+    "@cerc-io/graph-cli": "0.32.0-watcher-ts-0.1.3",
+    "@graphprotocol/graph-ts": "npm:@cerc-io/graph-ts@0.27.0-watcher-ts-0.1.3",
     "abi": "workspace:*",
     "assemblyscript": "^0.19.20",
     "matchstick-as": "0.5.0",


### PR DESCRIPTION
Part of [Generate watchers for sushiswap subgraphs deployed in graph-node](https://www.notion.so/Generate-watchers-for-sushiswap-subgraphs-deployed-in-graph-node-b3f2e475373d4ab1887d9f8720bd5ae6)